### PR TITLE
Scan tests and fixes

### DIFF
--- a/aioelasticsearch/helpers.py
+++ b/aioelasticsearch/helpers.py
@@ -161,6 +161,9 @@ class Scan:
 
         hits = resp['hits']['hits']
 
+        if '_scroll_id' in resp:
+            self._scroll_id = resp['_scroll_id']
+
         self.__found += len(hits)
 
         self.__has_more = self.__found < self._total

--- a/aioelasticsearch/helpers.py
+++ b/aioelasticsearch/helpers.py
@@ -138,7 +138,7 @@ class Scan:
 
         hits = resp['hits']['hits']
 
-        self._scroll_id = resp.get('_scroll_id')
+        self._scroll_id = resp['_scroll_id']
 
         self._total = resp['hits']['total']
 
@@ -161,8 +161,7 @@ class Scan:
 
         hits = resp['hits']['hits']
 
-        if '_scroll_id' in resp:
-            self._scroll_id = resp['_scroll_id']
+        self._scroll_id = resp['_scroll_id']
 
         self.__found += len(hits)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import asyncio
+import sys
 
 import pytest
-
 from aioelasticsearch import Elasticsearch
 
 
@@ -85,3 +85,9 @@ def pytest_pyfunc_call(pyfuncitem):
         loop.run_until_complete(pyfuncitem.obj(**testargs))
 
         return True
+
+
+def pytest_ignore_collect(path, config):
+    if 'py35' in str(path):
+        if sys.version_info < (3, 5, 0):
+            return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+
 from aioelasticsearch import Elasticsearch
 
 
@@ -35,13 +36,26 @@ def es(loop):
         'DELETE',
         '/_all',
     )
-    coros = [delete_template, delete_all]
-    coro = asyncio.gather(*coros, loop=loop)
+    remove_coros = [delete_template, delete_all]
+
+    coro = asyncio.gather(*remove_coros, loop=loop)
     loop.run_until_complete(coro)
 
     try:
         yield es
     finally:
+        delete_template = es.transport.perform_request(
+            'DELETE',
+            '/_template/*',
+        )
+        delete_all = es.transport.perform_request(
+            'DELETE',
+            '/_all',
+        )
+
+        remove_coros = [delete_template, delete_all]
+        coro = asyncio.gather(*remove_coros, loop=loop)
+        loop.run_until_complete(coro)
         loop.run_until_complete(es.close())
 
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 
+from aioelasticsearch import NotFoundError
 from aioelasticsearch.helpers import Scan
 
 from tests.utils import populate
@@ -58,8 +59,8 @@ def test_scan_equal_chunks(loop, es, scroll_size):
             for doc in docs:
                 ids.add(doc['_id'])
 
-    # check number of unique doc ids
-    assert len(ids) == n
+        # check number of unique doc ids
+        assert len(ids) == n == scan.total
 
     # check number of docs in a scroll
     expected_scroll_sizes = [scroll_size] * (n // scroll_size)
@@ -68,3 +69,58 @@ def test_scan_equal_chunks(loop, es, scroll_size):
 
     scroll_sizes = [len(scroll) for scroll in data]
     assert scroll_sizes == expected_scroll_sizes
+
+
+@pytest.mark.run_loop
+@asyncio.coroutine
+def test_scan_has_more(loop, es):
+    index = 'test_aioes'
+    doc_type = 'type_1'
+    n = 10
+    scroll_size = 3
+    yield from populate(es, index, doc_type, n, loop=loop)
+
+    with Scan(
+        es,
+        index=index,
+        doc_type=doc_type,
+        size=scroll_size,
+    ) as scan:
+        yield from scan.scroll()
+        assert scan.has_more
+
+        for scroll in scan:
+            yield from scroll
+
+        with pytest.raises(StopIteration):
+            next(scan)
+
+        assert not scan.has_more
+
+
+@pytest.mark.run_loop
+@asyncio.coroutine
+def test_scan_clear_scroll(loop, es):
+    index = 'test_aioes'
+    doc_type = 'type_1'
+    n = 10
+    scroll_size = 3
+    yield from populate(es, index, doc_type, n, loop=loop)
+
+    with Scan(
+        es,
+        index=index,
+        doc_type=doc_type,
+        size=scroll_size,
+    ) as scan:
+        yield from scan.scroll()
+
+        yield from scan.clear_scroll()
+
+        with pytest.raises(NotFoundError):
+            for scroll in scan:
+                yield from scroll
+
+        # run cleared scroll
+        with pytest.raises(AssertionError):
+            yield from scan.scroll()

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -27,6 +27,7 @@ def test_scan_initial_raises(loop, es):
 
 
 @pytest.mark.parametrize('n,scroll_size', [
+    (0, 1),  # no results
     (6, 6),  # 1 scroll
     (6, 8),  # 1 scroll
     (6, 3),  # 2 scrolls
@@ -54,10 +55,12 @@ def test_scan_equal_chunks_for_loop(loop, es, n, scroll_size):
 
         for scroll in scan:
             docs = yield from scroll
-            data.append(docs)
 
-            for doc in docs:
-                ids.add(doc['_id'])
+            if docs:
+                data.append(docs)
+
+                for doc in docs:
+                    ids.add(doc['_id'])
 
         # check number of unique doc ids
         assert len(ids) == n == scan.total
@@ -72,6 +75,7 @@ def test_scan_equal_chunks_for_loop(loop, es, n, scroll_size):
 
 
 @pytest.mark.parametrize('n,scroll_size', [
+    (0, 1),  # no results
     (6, 6),  # 1 scroll
     (6, 8),  # 1 scroll
     (6, 3),  # 2 scrolls
@@ -100,8 +104,9 @@ def test_scan_equal_chunks_while_loop(loop, es, n, scroll_size):
 
         while True:
             docs = yield from next(scan)
-            data.append(docs)
-            ids |= set([doc['_id'] for doc in docs])
+            if docs:
+                data.append(docs)
+                ids |= set([doc['_id'] for doc in docs])
 
             if not scan.has_more:
                 break

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -27,19 +27,19 @@ def test_scan_initial_raises(loop, es):
         loop.run_until_complete(scan.search())
 
 
-@pytest.mark.parametrize('scroll_size', [
-    1,
-    5,
-    7,
-    10,
-    15,
+@pytest.mark.parametrize('n,scroll_size', [
+    (6, 6),  # 1 scroll
+    (6, 8),  # 1 scroll
+    (6, 3),  # 2 scrolls
+    (6, 4),  # 2 scrolls
+    (6, 2),  # 3 scrolls
+    (6, 1),  # 6 scrolls
 ])
 @pytest.mark.run_loop
 @asyncio.coroutine
-def test_scan_equal_chunks(loop, es, scroll_size):
+def test_scan_equal_chunks_for_loop(loop, es, n, scroll_size):
     index = 'test_aioes'
     doc_type = 'type_1'
-    n = 10
     yield from populate(es, index, doc_type, n, loop=loop)
 
     ids = set()

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -116,6 +116,7 @@ def test_scan_equal_chunks_while_loop(loop, es, n, scroll_size):
     scroll_sizes = [len(scroll) for scroll in data]
     assert scroll_sizes == expected_scroll_sizes
 
+
 @pytest.mark.run_loop
 @asyncio.coroutine
 def test_scan_has_more(loop, es):

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,70 @@
+import asyncio
+
+import pytest
+
+from aioelasticsearch.helpers import Scan
+
+from tests.utils import populate
+
+
+def test_scan_initial_raises(loop, es):
+    scan = Scan(es)
+
+    with pytest.raises(AssertionError):
+        scan.scroll_id
+
+    with pytest.raises(AssertionError):
+        scan.total
+
+    with pytest.raises(AssertionError):
+        scan.has_more
+
+    with pytest.raises(AssertionError):
+        next(scan)
+
+    with pytest.raises(AssertionError):
+        loop.run_until_complete(scan.search())
+
+
+@pytest.mark.parametrize('scroll_size', [
+    1,
+    5,
+    7,
+    10,
+    15,
+])
+@pytest.mark.run_loop
+@asyncio.coroutine
+def test_scan_equal_chunks(loop, es, scroll_size):
+    index = 'test_aioes'
+    doc_type = 'type_1'
+    n = 10
+    yield from populate(es, index, doc_type, n, loop=loop)
+
+    ids = set()
+    data = []
+    with Scan(
+        es,
+        index=index,
+        doc_type=doc_type,
+        size=scroll_size,
+    ) as scan:
+        yield from scan.scroll()
+
+        for scroll in scan:
+            docs = yield from scroll
+            data.append(docs)
+
+            for doc in docs:
+                ids.add(doc['_id'])
+
+    # check number of unique doc ids
+    assert len(ids) == n
+
+    # check number of docs in a scroll
+    expected_scroll_sizes = [scroll_size] * (n // scroll_size)
+    if n % scroll_size != 0:
+        expected_scroll_sizes.append(n % scroll_size)
+
+    scroll_sizes = [len(scroll) for scroll in data]
+    assert scroll_sizes == expected_scroll_sizes

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -4,12 +4,11 @@ import pytest
 
 from aioelasticsearch import NotFoundError
 from aioelasticsearch.helpers import Scan
-
 from tests.utils import populate
 
 
 def test_scan_initial_raises(loop, es):
-    scan = Scan(es)
+    scan = Scan(es, loop=loop)
 
     with pytest.raises(AssertionError):
         scan.scroll_id
@@ -49,6 +48,7 @@ def test_scan_equal_chunks_for_loop(loop, es, n, scroll_size):
         index=index,
         doc_type=doc_type,
         size=scroll_size,
+        loop=loop,
     ) as scan:
         yield from scan.scroll()
 
@@ -93,6 +93,7 @@ def test_scan_equal_chunks_while_loop(loop, es, n, scroll_size):
         index=index,
         doc_type=doc_type,
         size=scroll_size,
+        loop=loop,
     ) as scan:
 
         yield from scan.scroll()
@@ -131,6 +132,7 @@ def test_scan_has_more(loop, es):
         index=index,
         doc_type=doc_type,
         size=scroll_size,
+        loop=loop,
     ) as scan:
         yield from scan.scroll()
         assert scan.has_more
@@ -158,6 +160,7 @@ def test_scan_clear_scroll(loop, es):
         index=index,
         doc_type=doc_type,
         size=scroll_size,
+        loop=loop,
     ) as scan:
         yield from scan.scroll()
 

--- a/tests/test_scan_py35.py
+++ b/tests/test_scan_py35.py
@@ -1,0 +1,48 @@
+import pytest
+
+from aioelasticsearch.helpers import Scan
+from tests.utils import populate
+
+
+@pytest.mark.parametrize('n,scroll_size', [
+    (0, 1),  # no results
+    (6, 6),  # 1 scroll
+    (6, 8),  # 1 scroll
+    (6, 3),  # 2 scrolls
+    (6, 4),  # 2 scrolls
+    (6, 2),  # 3 scrolls
+    (6, 1),  # 6 scrolls
+])
+@pytest.mark.run_loop
+async def test_scan_equal_chunks_for_loop(loop, es, n, scroll_size):
+    index = 'test_aioes'
+    doc_type = 'type_1'
+    await populate(es, index, doc_type, n, loop=loop)
+
+    ids = set()
+    data = []
+    async with Scan(
+        es,
+        index=index,
+        doc_type=doc_type,
+        size=scroll_size,
+        loop=loop,
+    ) as scan:
+
+        async for scroll in scan:
+            if scroll:
+                data.append(scroll)
+
+                for doc in scroll:
+                    ids.add(doc['_id'])
+
+        # check number of unique doc ids
+        assert len(ids) == n == scan.total
+
+    # check number of docs in a scroll
+    expected_scroll_sizes = [scroll_size] * (n // scroll_size)
+    if n % scroll_size != 0:
+        expected_scroll_sizes.append(n % scroll_size)
+
+    scroll_sizes = [len(scroll) for scroll in data]
+    assert scroll_sizes == expected_scroll_sizes

--- a/tests/test_scan_py35.py
+++ b/tests/test_scan_py35.py
@@ -14,7 +14,7 @@ from tests.utils import populate
     (6, 1),  # 6 scrolls
 ])
 @pytest.mark.run_loop
-async def test_scan_equal_chunks_for_loop(loop, es, n, scroll_size):
+async def test_scan_equal_chunks_for_loop(loop, es, n, scroll_size):  # noqa
     index = 'test_aioes'
     doc_type = 'type_1'
     await populate(es, index, doc_type, n, loop=loop)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,29 @@
+import asyncio
+
+
+@asyncio.coroutine
+def populate(es, index, doc_type, n, *, loop):  # TODO: check for * python version
+    url_pattern = '/{index}/{doc_type}/{_id}'
+
+    coros = []
+
+    for i in range(n):
+        url = url_pattern.format(
+            index=index,
+            doc_type=doc_type,
+            _id=i,
+        )
+        body = {
+            'foo': i,
+            'bar': i,
+        }
+        coros.append(
+            es.transport.perform_request('PUT', url=url, body=body),
+        )
+
+    yield from asyncio.gather(*coros, loop=loop)
+
+    yield from es.transport.perform_request(
+        'POST',
+        '/test_aioes/_refresh'
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,28 +2,22 @@ import asyncio
 
 
 @asyncio.coroutine
-def populate(es, index, doc_type, n, *, loop):  # TODO: check for * python version
-    url_pattern = '/{index}/{doc_type}/{_id}'
-
+def populate(es, index, doc_type, n, *, loop):
     coros = []
 
     for i in range(n):
-        url = url_pattern.format(
-            index=index,
-            doc_type=doc_type,
-            _id=i,
-        )
         body = {
             'foo': i,
             'bar': i,
         }
         coros.append(
-            es.transport.perform_request('PUT', url=url, body=body),
+            es.index(
+                index=index,
+                doc_type=doc_type,
+                id=i,
+                body=body,
+                refresh=True,
+            ),
         )
 
     yield from asyncio.gather(*coros, loop=loop)
-
-    yield from es.transport.perform_request(
-        'POST',
-        '/test_aioes/_refresh'
-    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,8 @@ import asyncio
 def populate(es, index, doc_type, n, *, loop):
     coros = []
 
+    yield from es.transport.perform_request('PUT', index)
+
     for i in range(n):
         body = {
             'foo': i,


### PR DESCRIPTION
- update `scroll_id` with each subsequent scroll request
(Important note from elasticsearch docs https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#CO22-4)
>The initial search request and each subsequent scroll request returns a new _scroll_id — only the most recent _scroll_id should be used.

- add tests for `aioelasticsearch.helpers.Scan`
