### PR TITLE
check whether old connection is closed

### DIFF
--- a/aioelasticsearch/connection.py
+++ b/aioelasticsearch/connection.py
@@ -68,6 +68,10 @@ class AIOHttpConnection(Connection):
                 ),
             )
 
+    @property
+    def closed(self):
+        return self.session.closed
+
     def close(self):
         return self.session.close()
 

--- a/aioelasticsearch/transport.py
+++ b/aioelasticsearch/transport.py
@@ -100,7 +100,7 @@ class AIOHttpTransport(Transport):
             # kept around.
             if hasattr(self, 'connection_pool'):
                 for (connection, old_host) in self.connection_pool.connection_opts:  # noqa
-                    if old_host == host:
+                    if old_host == host and not connection.session.closed:
                         return connection
 
             kwargs = self.kwargs.copy()

--- a/aioelasticsearch/transport.py
+++ b/aioelasticsearch/transport.py
@@ -100,7 +100,7 @@ class AIOHttpTransport(Transport):
             # kept around.
             if hasattr(self, 'connection_pool'):
                 for (connection, old_host) in self.connection_pool.connection_opts:  # noqa
-                    if old_host == host and not connection.session.closed:
+                    if old_host == host and not connection.closed:
                         return connection
 
             kwargs = self.kwargs.copy()


### PR DESCRIPTION
1. When we try to sniff hosts, we are closing all connections except for seeds:
`yield from self.connection_pool.close(seeds=self.seed_connections)`
https://github.com/wikibusiness/aioelasticsearch/blob/master/aioelasticsearch/transport.py#L189

2. After that we create new connection pool with `hosts` connections:
`self.set_connections(hosts)`
https://github.com/wikibusiness/aioelasticsearch/blob/master/aioelasticsearch/transport.py#L191

The problem is that we close `not seed` connection at step `1` and it will be in a new connection pool inspite of it is closed.

So, we need to check whether connection is closed.