### PR TITLE
Origin driver issues: surrogatepass and scheme checking

### DIFF
--- a/aioelasticsearch/connection.py
+++ b/aioelasticsearch/connection.py
@@ -31,7 +31,7 @@ class AIOHttpConnection(Connection):
         loop,
         **kwargs
     ):
-        super().__init__(host=host, port=port, **kwargs)
+        super().__init__(host=host, port=port, use_ssl=use_ssl, **kwargs)
 
         if headers is None:
             headers = {}
@@ -52,7 +52,7 @@ class AIOHttpConnection(Connection):
         self.verify_certs = verify_certs
 
         self.base_url = URL('http%s://%s:%d%s/' % (
-            's' if use_ssl else '', host, port, self.url_prefix,
+            's' if self.use_ssl else '', host, port, self.url_prefix,
         ))
 
         self.session = kwargs.get('session')

--- a/aioelasticsearch/transport.py
+++ b/aioelasticsearch/transport.py
@@ -312,7 +312,7 @@ class AIOHttpTransport(Transport):
 
         if body is not None:
             try:
-                body = body.encode('utf-8')
+                body = body.encode('utf-8', 'surrogatepass')
             except (UnicodeDecodeError, AttributeError):
                 # bytes/str - no need to re-encode
                 pass

--- a/aioelasticsearch/transport.py
+++ b/aioelasticsearch/transport.py
@@ -111,12 +111,6 @@ class AIOHttpTransport(Transport):
             kwargs.update(host)
             kwargs['loop'] = self.loop
 
-            if 'scheme' in host and host['scheme'] != self.connection_class.transport_schema:  # noqa
-                raise ImproperlyConfigured(
-                    'Scheme specified in connection (%s) is not the same as the connection class (%s) specifies (%s).' % (  # noqa
-                        host['scheme'], self.connection_class.__name__, self.connection_class.transport_schema,  # noqa
-                    ),
-                )
             return self.connection_class(**kwargs)
 
         connections = map(_create_connection, hosts)

--- a/aioelasticsearch/transport.py
+++ b/aioelasticsearch/transport.py
@@ -3,8 +3,7 @@ import logging
 from itertools import chain
 
 from elasticsearch.exceptions import (ConnectionError, ConnectionTimeout,
-                                      ImproperlyConfigured, SerializationError,
-                                      TransportError)
+                                      SerializationError, TransportError)
 from elasticsearch.serializer import (DEFAULT_SERIALIZERS, Deserializer,
                                       JSONSerializer)
 from elasticsearch.transport import Transport, get_host_info

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -25,7 +25,7 @@ class DummyConnection(AIOHttpConnection):
 @pytest.mark.run_loop
 @asyncio.coroutine
 def test_body_surrogates_replaced_encoded_into_bytes(loop):
-    t = AIOHttpTransport([], connection_class=DummyConnection, loop=loop)
+    t = AIOHttpTransport([{}], connection_class=DummyConnection, loop=loop)
 
     yield from t.perform_request('GET', '/', body='你好\uda6a')
     conn = yield from t.get_connection()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -25,7 +25,7 @@ class DummyConnection(AIOHttpConnection):
 @pytest.mark.run_loop
 @asyncio.coroutine
 def test_body_surrogates_replaced_encoded_into_bytes(loop):
-    t = AIOHttpTransport([{}], connection_class=DummyConnection, loop=loop)
+    t = AIOHttpTransport([], connection_class=DummyConnection, loop=loop)
 
     yield from t.perform_request('GET', '/', body='你好\uda6a')
     conn = yield from t.get_connection()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,36 @@
+import asyncio
+
+import pytest
+from aioelasticsearch import AIOHttpTransport
+from aioelasticsearch.connection import AIOHttpConnection
+
+
+class DummyConnection(AIOHttpConnection):
+    def __init__(self, **kwargs):
+        self.exception = kwargs.pop('exception', None)
+        self.status = kwargs.pop('status', 200)
+        self.data = kwargs.pop('data', '{}')
+        self.headers = kwargs.pop('headers', {})
+        self.calls = []
+        super().__init__(**kwargs)
+
+    @asyncio.coroutine
+    def perform_request(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        if self.exception:
+            raise self.exception
+        return self.status, self.headers, self.data
+
+
+@pytest.mark.run_loop
+@asyncio.coroutine
+def test_body_surrogates_replaced_encoded_into_bytes(loop):
+    t = AIOHttpTransport([{}], connection_class=DummyConnection, loop=loop)
+
+    yield from t.perform_request('GET', '/', body='你好\uda6a')
+    conn = yield from t.get_connection()
+
+    assert len(conn.calls) == 1
+    assert ('GET', '/', None, b'\xe4\xbd\xa0\xe5\xa5\xbd\xed\xa9\xaa') == conn.calls[0][0]  # noqa
+
+    yield from t.close()


### PR DESCRIPTION
port issues fixes from original `elasticsearch-py` driver:

- https://github.com/elastic/elasticsearch-py/commit/d6fb95353ef4ff733139ad45a208bdcbbf1b3edc
- https://github.com/elastic/elasticsearch-py/commit/d336c571b913720cb42e3c69229f6fa7a6371dfb#diff-dbbae72751bd3bf6a6bc3007bdbef709L76