### PR TITLE
exceptions.py

### DIFF
--- a/aioelasticsearch/__init__.py
+++ b/aioelasticsearch/__init__.py
@@ -1,7 +1,6 @@
 import asyncio
 
 from elasticsearch import Elasticsearch as _Elasticsearch  # isort:skip
-from elasticsearch.exceptions import *  # noqa # isort:skip
 
 from elasticsearch.connection_pool import (  # noqa # isort:skip
     ConnectionSelector, RoundRobinSelector,
@@ -9,6 +8,7 @@ from elasticsearch.connection_pool import (  # noqa # isort:skip
 from elasticsearch.serializer import JSONSerializer  # noqa # isort:skip
 
 from .compat import PY_350  # isort:skip
+from .exceptions import *  # noqa # isort:skip
 from .pool import AIOHttpConnectionPool  # noqa # isort:skip
 from .transport import AIOHttpTransport  # isort:skip
 

--- a/aioelasticsearch/connection.py
+++ b/aioelasticsearch/connection.py
@@ -9,9 +9,9 @@ if AIOHTTP_2:
 else:
     from aiohttp.errors import ClientError
 
+from .exceptions import ConnectionError, ConnectionTimeout, SSLError  # noqa # isort:skip
+
 from elasticsearch.connection import Connection  # noqa # isort:skip
-from elasticsearch.exceptions import (ConnectionError, ConnectionTimeout,  # noqa # isort:skip
-                                      SSLError)
 from yarl import URL  # noqa # isort:skip
 
 

--- a/aioelasticsearch/exceptions.py
+++ b/aioelasticsearch/exceptions.py
@@ -1,0 +1,1 @@
+from elasticsearch.exceptions import *  # noqa

--- a/aioelasticsearch/pool.py
+++ b/aioelasticsearch/pool.py
@@ -4,9 +4,9 @@ import logging
 import random
 
 from elasticsearch.connection_pool import ConnectionSelector
-from elasticsearch.exceptions import ImproperlyConfigured
 
 from .compat import create_future
+from .exceptions import ImproperlyConfigured
 
 logger = logging.getLogger('elasticsearch')
 

--- a/aioelasticsearch/transport.py
+++ b/aioelasticsearch/transport.py
@@ -2,14 +2,14 @@ import asyncio
 import logging
 from itertools import chain
 
-from elasticsearch.exceptions import (ConnectionError, ConnectionTimeout,
-                                      SerializationError, TransportError)
 from elasticsearch.serializer import (DEFAULT_SERIALIZERS, Deserializer,
                                       JSONSerializer)
 from elasticsearch.transport import Transport, get_host_info
 
 from .compat import ensure_future
 from .connection import AIOHttpConnection
+from .exceptions import (ConnectionError, ConnectionTimeout,
+                         SerializationError, TransportError)
 from .pool import AIOHttpConnectionPool, DummyConnectionPool
 
 logger = logging.getLogger('elasticsearch')


### PR DESCRIPTION
port `elasticsearch-py` exceptions so that to keep interface clear and use:
`from aioelasticsearch.exceptions import NotFoundError, ...` 