### PR TITLE
Pin elasticsearch-py to 5.4.0+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ async-timeout==1.2.1
 chardet==3.0.4
 coverage==4.3.4
 decorator==4.0.11
-elasticsearch==5.2.0
+elasticsearch==5.4.0
 flake8==3.3.0
 ipdb==0.10.2
 ipython==5.3.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     description='aioelasticsearch-py wrapper for asyncio',
     long_description=read('README.rst'),
     install_requires=[
-        'elasticsearch>=5.0.0,<6.0.0',
+        'elasticsearch>=5.4.0,<6.0.0',
         'aiohttp>=1.3.0',
     ],
     packages=['aioelasticsearch'],


### PR DESCRIPTION
Doesn't work on previous versions