### PR TITLE
Fix scan swallow NotFoundError

### DIFF
--- a/aioelasticsearch/__init__.py
+++ b/aioelasticsearch/__init__.py
@@ -1,7 +1,6 @@
 import asyncio
 
 from elasticsearch import Elasticsearch as _Elasticsearch  # noqa # isort:skip
-
 from elasticsearch.connection_pool import (ConnectionSelector, # noqa # isort:skip
                                            RoundRobinSelector)
 from elasticsearch.serializer import JSONSerializer  # noqa # isort:skip
@@ -11,7 +10,7 @@ from .pool import AIOHttpConnectionPool  # noqa # isort:skip
 from .transport import AIOHttpTransport  # noqa # isort:skip
 
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 
 class Elasticsearch(_Elasticsearch):

--- a/aioelasticsearch/transport.py
+++ b/aioelasticsearch/transport.py
@@ -319,7 +319,7 @@ class AIOHttpTransport(Transport):
 
         if body is not None:
             try:
-                body = body.encode('utf-8', 'surrogatepass')
+                body = body.encode('utf-8')
             except (UnicodeDecodeError, AttributeError):
                 # bytes/str - no need to re-encode
                 pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def pytest_generate_tests(metafunc):
             tags = ['5.5.1']
         else:
             tags = list(tags)
-        metafunc.parametrize('es_tag', tags, scope='session')
+        metafunc.parametrize("es_tag", tags, scope='session')
 
 
 @pytest.fixture(scope='session')
@@ -144,9 +144,11 @@ def es_clean(es_container):
             http_auth=es_container['auth'],
         )
 
-        es.transport.perform_request('DELETE', '/_template/*')
-        es.transport.perform_request('DELETE', '/_all')
-        es.transport.close()
+        try:
+            es.transport.perform_request('DELETE', '/_template/*')
+            es.transport.perform_request('DELETE', '/_all')
+        finally:
+            es.transport.close()
 
     return do
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,7 @@ def es_container(docker, session_id, es_tag, request):
     atexit.register(defer)
 
     if request.config.option.local_docker:
-        docker_host = '127.0.0.1'
+        docker_host = '0.0.0.0'
     else:
         inspection = docker.api.inspect_container(container.id)
         docker_host = inspection['NetworkSettings']['IPAddress']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,7 @@ def es_container(docker, session_id, es_tag, request):
         finally:
             es.transport.close()
     else:
-        pytest.fail('Cannot start elastic server')
+        pytest.fail("Cannot start elastic server")
 
     return {
         'host': docker_host,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,14 +40,14 @@ def docker():
 
 
 def pytest_addoption(parser):
-    parser.addoption('--es_tag', action='append', default=[],
-                     help=('Elasticsearch server versions. '
-                           'May be used several times. '
-                           '5.5.1 by default'))
-    parser.addoption('--no-pull', action='store_true', default=False,
-                     help='Don\'t perform docker images pulling')
-    parser.addoption('--local-docker', action='store_true', default=False,
-                     help='Use 0.0.0.0 as docker host, useful for MacOs X')
+    parser.addoption("--es_tag", action="append", default=[],
+                     help=("Elasticsearch server versions. "
+                           "May be used several times. "
+                           "5.5.1 by default"))
+    parser.addoption("--no-pull", action="store_true", default=False,
+                     help="Don't perform docker images pulling")
+    parser.addoption("--local-docker", action="store_true", default=False,
+                     help="Use 0.0.0.0 as docker host, useful for MacOs X")
 
 
 def pytest_generate_tests(metafunc):
@@ -71,9 +71,7 @@ def unused_port():
 
 @pytest.fixture(scope='session')
 def es_container(docker, session_id, es_tag, unused_port, request):
-    image = 'docker.elastic.co/elasticsearch/elasticsearch:{es_tag}'.format(
-        es_tag=es_tag,
-    )
+    image = 'docker.elastic.co/elasticsearch/elasticsearch:{}'.format(es_tag)
 
     if not request.config.option.no_pull:
         docker.images.pull(image)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 import asyncio
 import gc
-import socket
 import time
 import uuid
 
 import elasticsearch
 import pytest
+from aiohttp.test_utils import unused_port
 from docker import from_env as docker_from_env
 
 import aioelasticsearch
@@ -30,6 +30,7 @@ def loop(request):
 
 @pytest.fixture(scope='session')
 def session_id():
+    '''Unique session identifier, random string.'''
     return str(uuid.uuid4())
 
 
@@ -61,16 +62,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture(scope='session')
-def unused_port():
-    def factory():
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(('127.0.0.1', 0))
-            return s.getsockname()[1]
-    return factory
-
-
-@pytest.fixture(scope='session')
-def es_container(docker, session_id, es_tag, unused_port, request):
+def es_container(docker, session_id, es_tag, request):
     image = 'docker.elastic.co/elasticsearch/elasticsearch:{}'.format(es_tag)
 
     if not request.config.option.no_pull:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import asyncio
+import gc
+import socket
 import time
 import uuid
 
@@ -6,7 +8,7 @@ import elasticsearch
 import pytest
 from docker import from_env as docker_from_env
 
-from aioelasticsearch import Elasticsearch
+import aioelasticsearch
 
 
 @pytest.fixture
@@ -17,14 +19,17 @@ def loop(request):
 
     yield loop
 
-    loop.call_soon(loop.stop)
-    loop.run_forever()
-    loop.close()
+    if not loop._closed:
+        loop.call_soon(loop.stop)
+        loop.run_forever()
+        loop.close()
+
+    gc.collect()
+    asyncio.set_event_loop(None)
 
 
 @pytest.fixture(scope='session')
 def session_id():
-    '''Unique session identifier, random string.'''
     return str(uuid.uuid4())
 
 
@@ -35,12 +40,14 @@ def docker():
 
 
 def pytest_addoption(parser):
-    parser.addoption("--es_tag", action="append", default=[],
-                     help=("Elasticsearch server versions. "
-                           "May be used several times. "
-                           "5.5.1 by default"))
-    parser.addoption("--no-pull", action="store_true", default=False,
-                     help="Don't perform docker images pulling")
+    parser.addoption('--es_tag', action='append', default=[],
+                     help=('Elasticsearch server versions. '
+                           'May be used several times. '
+                           '5.5.1 by default'))
+    parser.addoption('--no-pull', action='store_true', default=False,
+                     help='Don\'t perform docker images pulling')
+    parser.addoption('--local-docker', action='store_true', default=False,
+                     help='Use 0.0.0.0 as docker host, useful for MacOs X')
 
 
 def pytest_generate_tests(metafunc):
@@ -50,66 +57,120 @@ def pytest_generate_tests(metafunc):
             tags = ['5.5.1']
         else:
             tags = list(tags)
-        metafunc.parametrize("es_tag", tags, scope='session')
+        metafunc.parametrize('es_tag', tags, scope='session')
 
 
 @pytest.fixture(scope='session')
-def es_container(docker, session_id, es_tag, request):
-    image = 'docker.elastic.co/elasticsearch/elasticsearch:{}'.format(es_tag)
+def unused_port():
+    def factory():
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(('127.0.0.1', 0))
+            return s.getsockname()[1]
+    return factory
+
+
+@pytest.fixture(scope='session')
+def es_container(docker, session_id, es_tag, unused_port, request):
+    image = 'docker.elastic.co/elasticsearch/elasticsearch:{es_tag}'.format(
+        es_tag=es_tag,
+    )
+
     if not request.config.option.no_pull:
         docker.images.pull(image)
-    container = docker.containers.run(
-        image, detach=True,
-        name='aioelasticsearch-'+session_id,
-        ports={'9200/tcp': None, '9300/tcp': None},
-        environment={'http.host': '0.0.0.0',
-                     'transport.host': '127.0.0.1'})
 
-    inspection = docker.api.inspect_container(container.id)
-    host = inspection['NetworkSettings']['IPAddress']
-    delay = 0.001
-    for i in range(100):
-        es = elasticsearch.Elasticsearch([host],
-                                         http_auth=('elastic', 'changeme'))
-        try:
-            es.transport.perform_request('GET', '/_nodes/_all/http')
-            break
-        except elasticsearch.TransportError as ex:
-            time.sleep(delay)
-            delay *= 2
-        finally:
-            es.transport.close()
-    else:
-        pytest.fail("Cannot start elastic server")
-    ret = {'container': container,
-           'host': host,
-           'port': 9200,
-           'auth': ('elastic', 'changeme')}
-    yield ret
+    es_port_9200 = str(unused_port())
+    es_port_9300 = str(unused_port())
 
-    container.kill()
-    container.remove()
+    auth = ('elastic', 'changeme')
+
+    container = None
+
+    try:
+        container = docker.containers.run(
+            image=image,
+            detach=True,
+            name='aioelasticsearch-' + session_id,
+            ports={
+                '9200/tcp': es_port_9200 + '/tcp',
+                '9300/tcp': es_port_9300 + '/tcp',
+            },
+            environment={
+                'http.host': '0.0.0.0',
+                'transport.host': '127.0.0.1',
+            },
+        )
+
+        if request.config.option.local_docker:
+            docker_ip_address = '0.0.0.0'
+        else:
+            inspection = docker.api.inspect_container(container.id)
+            docker_ip_address = inspection['NetworkSettings']['IPAddress']
+
+        delay = 0.1
+        for i in range(10):
+            es = elasticsearch.Elasticsearch(
+                [{
+                    'host': docker_ip_address,
+                    'port': es_port_9200,
+                }],
+                http_auth=auth,
+            )
+
+            try:
+                es.transport.perform_request('GET', '/_nodes/_all/http')
+                break
+            except elasticsearch.TransportError as ex:
+                time.sleep(delay)
+                delay *= 2
+            finally:
+                es.transport.close()
+        else:
+            pytest.fail('Cannot start elastic server')
+
+        ret = {
+            'container': container,
+            'host': docker_ip_address,
+            'port': es_port_9200,
+            'auth': auth,
+        }
+
+        yield ret
+    finally:
+        if container is not None:
+            container.kill()
+            container.remove()
 
 
 @pytest.fixture
 def es_server(es_container):
-    host = es_container['host']
-    es = elasticsearch.Elasticsearch([host],
-                                     http_auth=('elastic', 'changeme'))
+    es = elasticsearch.Elasticsearch(
+        hosts=[{
+            'host': es_container['host'],
+            'port': es_container['port'],
+        }],
+        http_auth=es_container['auth'],
+    )
 
     es.transport.perform_request('DELETE', '/_template/*')
     es.transport.perform_request('DELETE', '/_all')
 
-    return es_container
+    yield es_container
+
+    es.transport.close()
 
 
 @pytest.fixture
-def es(loop, es_server):
-    es = Elasticsearch(loop=loop, hosts=[{'host': es_server['host'],
-                                          'port': es_server['port']}],
-                       http_auth=es_server['auth'])
-    yield es
-    loop.run_until_complete(es.close())
+def es(es_server, auto_close, loop):
+    es = aioelasticsearch.Elasticsearch(
+        hosts=[{
+            'host': es_server['host'],
+            'port': es_server['port'],
+        }],
+        http_auth=es_server['auth'],
+        loop=loop,
+    )
+
+    return auto_close(es)
 
 
 @pytest.fixture
@@ -121,6 +182,7 @@ def auto_close(loop):
         return arg
 
     yield f
+
     for arg in close_list:
         loop.run_until_complete(arg.close())
 
@@ -167,9 +229,9 @@ def populate(loop):
                     doc_type=doc_type,
                     id=str(i),
                     body=body,
-                    refresh=True,
                 ),
             )
 
         await asyncio.gather(*coros, loop=loop)
+        await es.indices.refresh()
     return do

--- a/tests/test_aioelasticsearch.py
+++ b/tests/test_aioelasticsearch.py
@@ -12,12 +12,10 @@ async def test_ping(es):
     assert ping
 
 
-def test_elastic_default_loop(loop, auto_close, es_server):
+def test_elastic_default_loop(auto_close, loop):
     asyncio.set_event_loop(loop)
 
-    es = Elasticsearch(hosts=[{'host': es_server['host'],
-                               'port': es_server['port']}],
-                       http_auth=es_server['auth'])
+    es = Elasticsearch()
 
     auto_close(es)
 

--- a/tests/test_aioelasticsearch.py
+++ b/tests/test_aioelasticsearch.py
@@ -12,19 +12,13 @@ async def test_ping(es):
     assert ping
 
 
-@pytest.mark.run_loop
-async def test_str_auth(es, es_server, loop):
-    async with Elasticsearch(loop=loop, hosts=[{'host': es_server['host'],
-                                                'port': es_server['port']}],
-                             http_auth=':'.join(es_server['auth'])) as es1:
-        await es1.ping()
-
-
-@pytest.mark.run_loop
-async def test_elastic_default_loop(es, loop, es_server):
+def test_elastic_default_loop(loop, auto_close, es_server):
     asyncio.set_event_loop(loop)
 
-    async with Elasticsearch(hosts=[{'host': es_server['host'],
-                                     'port': es_server['port']}],
-                             http_auth=':'.join(es_server['auth'])) as es1:
-        assert es1.loop is loop
+    es = Elasticsearch(hosts=[{'host': es_server['host'],
+                               'port': es_server['port']}],
+                       http_auth=es_server['auth'])
+
+    auto_close(es)
+
+    assert es.loop is loop

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -51,7 +51,7 @@ async def test_scan_simple(es, populate):
         doc_type=doc_type,
         size=scroll_size,
     ) as scan:
-        assert scan.scroll_id is not None
+        assert isinstance(scan.scroll_id, str)
         assert scan.total == 10
         async for doc in scan:
             ids.add(doc['_id'])

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -23,19 +23,6 @@ class DummyConnection(AIOHttpConnection):
 
 
 @pytest.mark.run_loop
-async def test_body_surrogates_replaced_encoded_into_bytes(loop, auto_close):
-    t = AIOHttpTransport([{}], connection_class=DummyConnection, loop=loop)
-    auto_close(t)
-
-    await t.perform_request('GET', '/', body='你好\uda6a')
-    conn = await t.get_connection()
-
-    assert len(conn.calls) == 1
-    assert ('GET', '/', None,
-            b'\xe4\xbd\xa0\xe5\xa5\xbd\xed\xa9\xaa') == conn.calls[0][0]
-
-
-@pytest.mark.run_loop
 async def test_custom_serializers(auto_close, loop):
     serializer = object()
     t = auto_close(AIOHttpTransport([{}],


### PR DESCRIPTION
* bumped to 0.3.1
* fixes `scan.scroll_id` returns `self._scroll_id`, fixed related tests
* removed silent swallow `NotFoundError` during scrolling, comes when search context do not exists anymore or scroll was explicitly cleared, added corresponding test
* removed `surrogatepass`, it was back-ported from upstream, which has reverted it in master
* refactor docker es runner to bind on random ports, added ability to run it on MacOS ;)
* `test_elastic_default_loop` must do not run inside coroutine, otherwise it will find loop anyway
* fixed hidden es container creation on `parametrize`